### PR TITLE
Create constructor from primitives method on Acquisitions Model

### DIFF
--- a/src/main/scala/com/gu/acquisitionsValueCalculatorClient/model/AcquisitionModel.scala
+++ b/src/main/scala/com/gu/acquisitionsValueCalculatorClient/model/AcquisitionModel.scala
@@ -4,8 +4,17 @@ import com.gu.fezziwig.CirceScroogeMacros._
 import io.circe.{Decoder, Encoder}
 import io.circe.generic.semiauto._
 import ophan.thrift.event._
+import io.circe.syntax._
+import io.circe.parser._
+import io.circe.Error
+
 
 case class AcquisitionModel(amount: Double, product: Product, currency: String, paymentFrequency: PaymentFrequency, paymentProvider: Option[PaymentProvider])
+case class AcquisitionModelFromPrimitives(amount: Double, product: String, currency: String, paymentFrequency: String, paymentProvider: Option[String])
+object AcquisitionModelFromPrimitives {
+  implicit val acquisitionModelFromPrimitivesDecoder: Encoder[AcquisitionModelFromPrimitives] = deriveEncoder
+}
+
 
 object AcquisitionModel {
   implicit val acquisitionEncode: Encoder[AcquisitionModel] = {
@@ -20,6 +29,11 @@ object AcquisitionModel {
     implicit val paymentProviderDecoder: Decoder[PaymentProvider] = decodeThriftEnum
     implicit val productDecoder: Decoder[Product] = decodeThriftEnum
     deriveDecoder
+  }
+
+  def fromPrimitives(amount: Double, product: String, currency: String, paymentFrequency: String, paymentProvider: Option[String]): Either[Error, AcquisitionModel] = {
+    val acquistionFromPrimitives  = AcquisitionModelFromPrimitives(amount, product, currency, paymentFrequency, paymentProvider).asJson.noSpaces
+    decode[AcquisitionModel](acquistionFromPrimitives)
   }
 
 }

--- a/src/test/scala/com/gu/acquisitionsValueCalculatorClient/services/AnnualisedValueTest.scala
+++ b/src/test/scala/com/gu/acquisitionsValueCalculatorClient/services/AnnualisedValueTest.scala
@@ -10,8 +10,23 @@ class AnnualisedValueTest extends FlatSpec with Matchers with OptionValues with 
 
   behavior of "AV service"
 
-  it should "get the coprrect AV" in {
+  it should "succesfully get AV from correct submission" in {
     val acquisition = AcquisitionModel(50, Product(1), "GBP", PaymentFrequency(1), Some(PaymentProvider(1)))
-    AnnualisedValueService.getAV(acquisition, "ophan") shouldBe Right(AnnualisedValueTwo(49.5))
+    AnnualisedValueService.getAV(acquisition, "ophan") should be ('right)
+  }
+
+  behavior of "from Primitives"
+
+
+  it should "succesfully return AcquisitionModel given valid input -  no payment provider" in {
+    AcquisitionModel.fromPrimitives(50, "CONTRIBUTION", "GBP", "ONE_OFF", None) should be ('right)
+  }
+
+  it should "succesfully return AcquisitionModel given valid input - valid payment provider" in {
+    AcquisitionModel.fromPrimitives(50, "CONTRIBUTION", "GBP", "ONE_OFF", Some("STRIPE")) should be ('right)
+  }
+
+  it should "reject invalid input -  invalid payment provider" in {
+    AcquisitionModel.fromPrimitives(50, "CONTRIBUTION", "GBP", "ONE_OFF", Some("STRIPES")) should be ('left)
   }
 }


### PR DESCRIPTION
When we call the AV calculator in ophan-data-lake, the data we need in order to calculate is in not encoded with the Thrift types that the calculator needs (for example, we want `product` to be a Thrift Enum, rather than a String). This PR adds a method on the `Acquisition Model` class that allows us to create an `AcquisitionModel` with the correct Thrift types. 