### PR TITLE
Remove model dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,11 +43,10 @@ publishTo :=
 
 libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.0.0" % "test",
-  "com.amazonaws" % "aws-java-sdk-core" % "1.11.218",
-  "com.amazonaws" % "aws-java-sdk-lambda" % "1.11.218",
+  "com.amazonaws" % "aws-java-sdk-core" % "1.11.77",
+  "com.amazonaws" % "aws-java-sdk-lambda" % "1.11.77",
   "org.typelevel" %% "cats-core" % "1.0.0-MF",
   "ch.qos.logback" % "logback-classic" % "1.1.7",
-  "com.gu" %% "ophan-event-model" % "0.0.1",
   "com.gu" %% "fezziwig" % "0.6",
   "io.circe" %% "circe-parser" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion

--- a/src/main/scala/com/gu/acquisitionsValueCalculatorClient/ProfileAwareCredentialsProviderChain.scala
+++ b/src/main/scala/com/gu/acquisitionsValueCalculatorClient/ProfileAwareCredentialsProviderChain.scala
@@ -1,0 +1,17 @@
+package etl.utils
+
+import com.amazonaws.auth._
+import com.amazonaws.auth.profile.ProfileCredentialsProvider
+
+case class ProfileAwareCredentialsProviderChain(profile: String) extends AWSCredentialsProvider {
+  val profileCredentialsProvider = new ProfileCredentialsProvider(profile)
+
+  val chain = new AWSCredentialsProviderChain(
+    new EnvironmentVariableCredentialsProvider,
+    new SystemPropertiesCredentialsProvider,
+    profileCredentialsProvider,
+    new InstanceProfileCredentialsProvider(false))
+
+  override def refresh(): Unit = chain.refresh()
+  override def getCredentials: AWSCredentials = chain.getCredentials
+}

--- a/src/main/scala/com/gu/acquisitionsValueCalculatorClient/model/AcquisitionModel.scala
+++ b/src/main/scala/com/gu/acquisitionsValueCalculatorClient/model/AcquisitionModel.scala
@@ -1,56 +1,12 @@
 package com.gu.acquisitionsValueCalculatorClient.model
 
-import com.gu.fezziwig.CirceScroogeMacros._
 import io.circe.{Decoder, Encoder}
 import io.circe.generic.semiauto._
-import ophan.thrift.event._
-import scala.reflect.ClassTag
 
-case class AcquisitionModel(amount: Double, product: Product, currency: String, paymentFrequency: PaymentFrequency, paymentProvider: Option[PaymentProvider])
+case class AcquisitionModel(amount: Double, product: String, currency: String, paymentFrequency: String, paymentProvider: Option[String])
 
 object AcquisitionModel {
-  implicit val acquisitionEncode: Encoder[AcquisitionModel] = {
-    implicit val paymentFrequencyEncoder: Encoder[PaymentFrequency] = encodeThriftEnum
-    implicit val paymentProviderEncoder: Encoder[PaymentProvider] = encodeThriftEnum
-    implicit val productEncoder: Encoder[Product] = encodeThriftEnum
-    deriveEncoder
-  }
+  implicit val acquisitionEncode: Encoder[AcquisitionModel] = deriveEncoder
 
-  implicit val acquisitionDecode: Decoder[AcquisitionModel] = {
-    implicit val paymentFrequencyDecoder: Decoder[PaymentFrequency] = decodeThriftEnum
-    implicit val paymentProviderDecoder: Decoder[PaymentProvider] = decodeThriftEnum
-    implicit val productDecoder: Decoder[Product] = decodeThriftEnum
-    deriveDecoder
-  }
-
-  def fromPrimitives(amount: Double, product: String, currency: String, paymentFrequency: String, paymentProvider: Option[String]): Either[String, AcquisitionModel] = {
-    import cats.syntax.either._
-    type R[A] = Either[String, Option[A]]
-
-    def error[A: ClassTag](value: String, classTag: ClassTag[A]): String = {
-      s"Error: $value is not a valid $classTag"
-    }
-
-    def toCamel(value: String): String = value.replaceAll("_", "")
-
-    def parseOptionalEnum [A: ClassTag](value: Option[String], valueOf: String => Option[A]) : R[A] = {
-      value.map(v => valueOf(toCamel(v))).fold[R[A]](Right(None)) {
-        case None => Left(error(value.getOrElse(""), reflect.classTag[A]))
-        case a => Right(a)
-      }
-    }
-
-    def parseEnum[A: ClassTag](value: String, valueOf: String => Option[A]): Either[String, A] = {
-      Either.fromOption(valueOf(toCamel(value)), error(value, reflect.classTag[A]))
-    }
-
-    for {
-      product <- parseEnum(product, Product.valueOf)
-      paymentFrequency <- parseEnum(paymentFrequency, PaymentFrequency.valueOf)
-      paymentProvider <- parseOptionalEnum(paymentProvider, PaymentProvider.valueOf)
-    } yield {
-      AcquisitionModel(amount, product, currency, paymentFrequency, paymentProvider)
-    }
-  }
-
+  implicit val acquisitionDecode: Decoder[AcquisitionModel] = deriveDecoder
 }

--- a/src/main/scala/com/gu/acquisitionsValueCalculatorClient/service/AnnualisedValueClient.scala
+++ b/src/main/scala/com/gu/acquisitionsValueCalculatorClient/service/AnnualisedValueClient.scala
@@ -2,13 +2,13 @@ package com.gu.acquisitionsValueCalculatorClient.service
 
 import com.amazonaws.ClientConfiguration
 import com.amazonaws.auth.AWSCredentialsProvider
-import com.amazonaws.regions.Regions
+import com.amazonaws.regions.{Region, Regions}
 import com.amazonaws.retry.{PredefinedRetryPolicies, RetryPolicy}
-import com.amazonaws.services.lambda.{AWSLambda, AWSLambdaClientBuilder}
+import com.amazonaws.services.lambda.{AWSLambda, AWSLambdaClient, AWSLambdaClientBuilder}
 
 object AnnualisedValueClient {
 
-  def getRegion = Option(System.getenv("AWS_DEFAULT_REGION")).map(Regions.fromName).getOrElse(Regions.EU_WEST_1)
+  val getRegion =  Region getRegion Regions.EU_WEST_1
 
   val clientConfig = new ClientConfiguration().withRetryPolicy(
     new RetryPolicy(
@@ -18,6 +18,8 @@ object AnnualisedValueClient {
       false
     )
   )
-  def createLambdaClient(implicit region:Regions, creds: AWSCredentialsProvider): AWSLambda =
-    AWSLambdaClientBuilder.standard().withRegion(region).withCredentials(creds).withClientConfiguration(clientConfig).build()
+  def createLambdaClient(creds: AWSCredentialsProvider): AWSLambda = {
+    getRegion.createClient(classOf[AWSLambdaClient], creds, null)
+   //AWSLambdaClientBuilder.standard().withRegion(region).withCredentials(creds).withClientConfiguration(clientConfig).build()
+  }
 }

--- a/src/main/scala/com/gu/acquisitionsValueCalculatorClient/service/AnnualisedValueClient.scala
+++ b/src/main/scala/com/gu/acquisitionsValueCalculatorClient/service/AnnualisedValueClient.scala
@@ -1,25 +1,14 @@
 package com.gu.acquisitionsValueCalculatorClient.service
 
-import com.amazonaws.ClientConfiguration
 import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.regions.{Region, Regions}
-import com.amazonaws.retry.{PredefinedRetryPolicies, RetryPolicy}
-import com.amazonaws.services.lambda.{AWSLambda, AWSLambdaClient, AWSLambdaClientBuilder}
+import com.amazonaws.services.lambda.{AWSLambda, AWSLambdaClient }
 
 object AnnualisedValueClient {
 
   val getRegion =  Region getRegion Regions.EU_WEST_1
 
-  val clientConfig = new ClientConfiguration().withRetryPolicy(
-    new RetryPolicy(
-      PredefinedRetryPolicies.DEFAULT_RETRY_CONDITION,
-      PredefinedRetryPolicies.DEFAULT_BACKOFF_STRATEGY,
-      20,
-      false
-    )
-  )
   def createLambdaClient(creds: AWSCredentialsProvider): AWSLambda = {
     getRegion.createClient(classOf[AWSLambdaClient], creds, null)
-   //AWSLambdaClientBuilder.standard().withRegion(region).withCredentials(creds).withClientConfiguration(clientConfig).build()
   }
 }

--- a/src/main/scala/com/gu/acquisitionsValueCalculatorClient/service/AnnualisedValueService.scala
+++ b/src/main/scala/com/gu/acquisitionsValueCalculatorClient/service/AnnualisedValueService.scala
@@ -7,6 +7,7 @@ import com.gu.acquisitionsValueCalculatorClient.model.{AVError, AcquisitionModel
 import io.circe.syntax._
 import io.circe.parser._
 import cats.syntax.either._
+import etl.utils.ProfileAwareCredentialsProviderChain
 
 
 
@@ -19,8 +20,9 @@ object AnnualisedValueService {
 
   def getAV(acquisitionModel: AcquisitionModel, accountName: String): Either[String, Double] = {
 
-    implicit val region: Regions = AnnualisedValueClient.getRegion
-    implicit val lambda = AnnualisedValueClient.createLambdaClient(region, new ProfileCredentialsProvider(accountName))
+    //implicit val region: Regions = AnnualisedValueClient.getRegion
+
+    implicit val lambda = AnnualisedValueClient.createLambdaClient(new ProfileAwareCredentialsProviderChain(accountName))
 
     val invokeRequest = new InvokeRequest
     invokeRequest.setFunctionName("acquisitions-value-calculator-PROD")

--- a/src/main/scala/com/gu/acquisitionsValueCalculatorClient/service/AnnualisedValueService.scala
+++ b/src/main/scala/com/gu/acquisitionsValueCalculatorClient/service/AnnualisedValueService.scala
@@ -1,7 +1,5 @@
 package com.gu.acquisitionsValueCalculatorClient.service
 
-import com.amazonaws.auth.profile.ProfileCredentialsProvider
-import com.amazonaws.regions.Regions
 import com.amazonaws.services.lambda.model.InvokeRequest
 import com.gu.acquisitionsValueCalculatorClient.model.{AVError, AcquisitionModel, AnnualisedValueResult, AnnualisedValueTwo}
 import io.circe.syntax._
@@ -19,8 +17,6 @@ object AnnualisedValueService {
   }
 
   def getAV(acquisitionModel: AcquisitionModel, accountName: String): Either[String, Double] = {
-
-    //implicit val region: Regions = AnnualisedValueClient.getRegion
 
     implicit val lambda = AnnualisedValueClient.createLambdaClient(new ProfileAwareCredentialsProviderChain(accountName))
 

--- a/src/test/scala/com/gu/acquisitionsValueCalculatorClient/services/AnnualisedValueTest.scala
+++ b/src/test/scala/com/gu/acquisitionsValueCalculatorClient/services/AnnualisedValueTest.scala
@@ -10,14 +10,14 @@ class AnnualisedValueTest extends FlatSpec with Matchers with OptionValues with 
 
 
   it should "succesfully return AcquisitionModel given valid input -  no payment provider" in {
-    AcquisitionModel.fromPrimitives(50, "CONTRIBUTION", "GBP", "ONE_OFF", None) should be ('right)
+    AcquisitionModel(50, "CONTRIBUTION", "GBP", "ONE_OFF", None) should be ('right)
   }
 
   it should "succesfully return AcquisitionModel given valid input - valid payment provider" in {
-    AcquisitionModel.fromPrimitives(50, "CONTRIBUTION", "GBP", "ONE_OFF", Some("STRIPE")) should be ('right)
+    AcquisitionModel(50, "CONTRIBUTION", "GBP", "ONE_OFF", Some("STRIPE")) should be ('right)
   }
 
   it should "reject invalid input -  invalid payment provider" in {
-    AcquisitionModel.fromPrimitives(50, "CONTRIBUTION", "GBP", "ONE_OFF", Some("STRIPES")) should be ('left)
+    AcquisitionModel(50, "CONTRIBUTION", "GBP", "ONE_OFF", Some("STRIPES")) should be ('left)
   }
 }

--- a/src/test/scala/com/gu/acquisitionsValueCalculatorClient/services/LambdaRunner.scala
+++ b/src/test/scala/com/gu/acquisitionsValueCalculatorClient/services/LambdaRunner.scala
@@ -2,12 +2,11 @@ package com.gu.acquisitionsValueCalculatorClient.services
 
 import com.gu.acquisitionsValueCalculatorClient.model.AcquisitionModel
 import com.gu.acquisitionsValueCalculatorClient.service.AnnualisedValueService
-import ophan.thrift.event.{PaymentFrequency, PaymentProvider, Product}
 import org.scalatest.concurrent.Eventually
 import org.scalatest.{Matchers, OptionValues}
 
 //For testing locally that the lambda is being called correctly. Run with "sbt test:run"
 object LambdaRunner extends App with Matchers with OptionValues with Eventually {
-  val acquisition = AcquisitionModel(50, Product(1), "GBP", PaymentFrequency(1), Some(PaymentProvider(1)))
+  val acquisition = AcquisitionModel(50, "CONTRIBUTION", "GBP", "ONE_OFF", Some("STRIPE"))
   AnnualisedValueService.getAV(acquisition, "ophan") should be ('right)
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.14"
+version in ThisBuild := "1.0.14-SNAPSHOT"


### PR DESCRIPTION
So that projects using this don't have to import the ophan-event-model dependency, this PR removes it and instead deals only with Strings, rather than Thrift Enums.

I also had to downgrade the aws version, for the same reason