### PR TITLE
Adding class definition

### DIFF
--- a/src/main/scala/com/gu/acquisitionsValueCalculatorClient/service/AnnualisedValueService.scala
+++ b/src/main/scala/com/gu/acquisitionsValueCalculatorClient/service/AnnualisedValueService.scala
@@ -7,8 +7,9 @@ import io.circe.parser._
 import cats.syntax.either._
 import com.gu.acquisitionsValueCalculatorClient.utils.ProfileAwareCredentialsProviderChain
 
+class AnnualisedValueService
 
-object AnnualisedValueService {
+object AnnualisedValueService extends AnnualisedValueService {
 
   def annualisedValueResultFromJson(json: String): Either[String, AnnualisedValueResult] = {
     decode[AnnualisedValueResult](json).leftMap(e => "Error: Unable to parse ( " + json + "). " + e.getMessage)


### PR DESCRIPTION
This adds a class definition for `AnnualisedValueService`. This allows consumers of the service to use the `AnnualisedValueService` as a `type`, and then extend this type if need (ie for mocking)