### PR TITLE
Downgrade cats version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,7 +45,7 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.0.0" % "test",
   "com.amazonaws" % "aws-java-sdk-core" % "1.11.77",
   "com.amazonaws" % "aws-java-sdk-lambda" % "1.11.77",
-  "org.typelevel" %% "cats-core" % "1.0.0-MF",
+  "org.typelevel" %% "cats-core" % "0.9.0",
   "ch.qos.logback" % "logback-classic" % "1.1.7",
   "com.gu" %% "fezziwig" % "0.6",
   "io.circe" %% "circe-parser" % circeVersion,


### PR DESCRIPTION
This downgrades the `cats-core` version so projects depending on this library do not need to upgrade.
As `cats-core` has introduce breaking changes to their api, having this library using the latest version is causing conflicts in other projects that have not yet upgraded. We should downgrade for now, and then upgrade once other projects have fixed their dependencies.