### PR TITLE
bump circe version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ scalacOptions ++= Seq(
 resolvers += Resolver.bintrayRepo("guardian", "ophan")
 resolvers += Resolver.sonatypeRepo("releases")
 
-val circeVersion = "0.7.0"
+val circeVersion = "0.8.0"
 
 scmInfo := Some(ScmInfo(
   url("https://github.com/guardian/acquisitions-value-calculator-client"),


### PR DESCRIPTION
Prevent circe evictions by having the version of circe used be the same as the version used by `"com.gu" %% "fezziwig" % "0.6"`.