### PR TITLE
don't create encoders and decoders using macros

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -48,8 +48,7 @@ libraryDependencies ++= Seq(
   "org.typelevel" %% "cats-core" % "0.9.0",
   "ch.qos.logback" % "logback-classic" % "1.1.7",
   "com.gu" %% "fezziwig" % "0.6",
-  "io.circe" %% "circe-parser" % circeVersion,
-  "io.circe" %% "circe-generic" % circeVersion
+  "io.circe" %% "circe-parser" % circeVersion
 )
 
 releaseCrossBuild := true // true if you cross-build the project for multiple Scala versions

--- a/src/main/scala/com/gu/acquisitionsValueCalculatorClient/model/AcquisitionModel.scala
+++ b/src/main/scala/com/gu/acquisitionsValueCalculatorClient/model/AcquisitionModel.scala
@@ -9,6 +9,8 @@ case class PrintOptionsModel(product: String, deliveryCountryCode: String)
 
 object PrintOptionsModel {
 
+  // Derived manually to circumvent issues that macro derived encoders and decoders where causing
+  // when this package was used in a Spark job.
   implicit val printOptionsModelDecoder: Decoder[PrintOptionsModel] = new Decoder[PrintOptionsModel] {
     override def apply(c: HCursor): Result[PrintOptionsModel] =
       for {
@@ -19,6 +21,8 @@ object PrintOptionsModel {
       }
   }
 
+  // Derived manually to circumvent issues that macro derived encoders and decoders where causing
+  // when this package was used in a Spark job.
   implicit val printOptionsModelEncoder: Encoder[PrintOptionsModel] = new Encoder[PrintOptionsModel] {
     override def apply(a: PrintOptionsModel): Json = Json.obj(
       "product" -> Json.fromString(a.product),
@@ -37,6 +41,8 @@ case class AcquisitionModel(
 
 object AcquisitionModel {
 
+  // Derived manually to circumvent issues that macro derived encoders and decoders where causing
+  // when this package was used in a Spark job.
   implicit val acquisitionModelDecoder: Decoder[AcquisitionModel] = new Decoder[AcquisitionModel] {
     override def apply(c: HCursor): Result[AcquisitionModel] =
       for {
@@ -58,6 +64,8 @@ object AcquisitionModel {
       }
   }
 
+  // Derived manually to circumvent issues that macro derived encoders and decoders where causing
+  // when this package was used in a Spark job.
   implicit val acquisitionModelEncoder: Encoder[AcquisitionModel] = new Encoder[AcquisitionModel] {
     override def apply(a: AcquisitionModel): Json = {
       var map = Map(

--- a/src/main/scala/com/gu/acquisitionsValueCalculatorClient/model/AnnualisedValueResult.scala
+++ b/src/main/scala/com/gu/acquisitionsValueCalculatorClient/model/AnnualisedValueResult.scala
@@ -1,15 +1,34 @@
 package com.gu.acquisitionsValueCalculatorClient.model
 
-import io.circe.{Decoder, Encoder}
-import io.circe.generic.semiauto._
-
-
+import cats.syntax.either._
+import io.circe.Decoder.Result
+import io.circe.{Decoder, HCursor}
 
 sealed trait AnnualisedValueResult
 
 object AnnualisedValueResult {
-  implicit val responseBodyDecoder: Decoder[AnnualisedValueResult] = deriveDecoder
-  implicit val responseBodyEncoder: Encoder[AnnualisedValueResult] = deriveEncoder
+
+  implicit val annualisedValueResultDecoder: Decoder[AnnualisedValueResult] = {
+    val annualisedValueTwoDecoder: Decoder[AnnualisedValueResult] = new Decoder[AnnualisedValueResult] {
+      override def apply(c: HCursor): Result[AnnualisedValueResult] =
+        for {
+          annualisedValueTwo <- c.downField("AnnualisedValueTwo").as[HCursor]
+          amount <- annualisedValueTwo.downField("amount").as[Double]
+        } yield {
+          AnnualisedValueTwo(amount)
+        }
+    }
+    val avErrorDecoder: Decoder[AnnualisedValueResult] = new Decoder[AnnualisedValueResult] {
+      override def apply(c: HCursor): Result[AnnualisedValueResult] =
+        for {
+          avError <- c.downField("AVError").as[HCursor]
+          error <- avError.downField("error").as[String]
+        } yield {
+          AVError(error)
+        }
+    }
+    annualisedValueTwoDecoder.or(avErrorDecoder)
+  }
 
   def fromResult(result: Either[String, Double]): AnnualisedValueResult = {
     result.fold(
@@ -20,5 +39,5 @@ object AnnualisedValueResult {
 }
 
 case class AnnualisedValueTwo(amount: Double) extends AnnualisedValueResult
-case class AVError(error: String) extends AnnualisedValueResult
 
+case class AVError(error: String) extends AnnualisedValueResult

--- a/src/main/scala/com/gu/acquisitionsValueCalculatorClient/model/AnnualisedValueResult.scala
+++ b/src/main/scala/com/gu/acquisitionsValueCalculatorClient/model/AnnualisedValueResult.scala
@@ -8,6 +8,8 @@ sealed trait AnnualisedValueResult
 
 object AnnualisedValueResult {
 
+  // Derived manually to circumvent issues that macro derived encoders and decoders where causing
+  // when this package was used in a Spark job.
   implicit val annualisedValueResultDecoder: Decoder[AnnualisedValueResult] = {
     val annualisedValueTwoDecoder: Decoder[AnnualisedValueResult] = new Decoder[AnnualisedValueResult] {
       override def apply(c: HCursor): Result[AnnualisedValueResult] =

--- a/src/test/scala/com/gu/acquisitionsValueCalculatorClient/model/AcquisitionModelTest.scala
+++ b/src/test/scala/com/gu/acquisitionsValueCalculatorClient/model/AcquisitionModelTest.scala
@@ -1,0 +1,68 @@
+package com.gu.acquisitionsValueCalculatorClient.model
+
+import io.circe.Json
+import io.circe.syntax._
+import org.scalatest.{EitherValues, FlatSpec, Matchers}
+
+class AcquisitionModelTest extends FlatSpec with Matchers with EitherValues {
+
+  behavior of "an acquisition model"
+
+  val acquisitionModel = AcquisitionModel(
+    amount = 10.0,
+    product = "SUBSCRIPTION",
+    currency = "GBP",
+    paymentFrequency = "ONE_OFF",
+    paymentProvider = Some("STRIPE"),
+    printOptions = Some(
+      PrintOptionsModel(
+        product = "SUBSCRIPTION",
+        deliveryCountryCode = "UK"
+      )
+    )
+  )
+
+  val json: Json = Json.obj(
+    "amount" -> Json.fromDoubleOrNull(10.0),
+    "product" -> Json.fromString("SUBSCRIPTION"),
+    "currency" -> Json.fromString("GBP"),
+    "paymentFrequency" -> Json.fromString("ONE_OFF"),
+    "paymentProvider" -> Json.fromString("STRIPE"),
+    "printOptions" -> Json.obj(
+      "product" -> Json.fromString("SUBSCRIPTION"),
+      "deliveryCountryCode" -> Json.fromString("UK")
+    )
+  )
+
+  it should "be able to be decoded from JSON" in {
+    json.as[AcquisitionModel].right.value shouldEqual acquisitionModel
+  }
+
+  it should "be able to be encoded to JSON" in {
+    acquisitionModel.asJson shouldEqual json
+  }
+
+  val acquisitionModelMissingFields = AcquisitionModel(
+    amount = 10.0,
+    product = "SUBSCRIPTION",
+    currency = "GBP",
+    paymentFrequency = "ONE_OFF",
+    paymentProvider = None,
+    printOptions = None
+  )
+
+  val jsonMissingFields: Json = Json.obj(
+    "amount" -> Json.fromDoubleOrNull(10.0),
+    "product" -> Json.fromString("SUBSCRIPTION"),
+    "currency" -> Json.fromString("GBP"),
+    "paymentFrequency" -> Json.fromString("ONE_OFF")
+  )
+
+  it should "be able to be decoded from JSON when the optional fields are missing" in {
+    jsonMissingFields.as[AcquisitionModel].right.value shouldEqual acquisitionModelMissingFields
+  }
+
+  it should "be able to be encoded to JSON when the optional fields are missing" in {
+    acquisitionModelMissingFields.asJson shouldEqual jsonMissingFields
+  }
+}

--- a/src/test/scala/com/gu/acquisitionsValueCalculatorClient/model/AnnualisedValueResultTest.scala
+++ b/src/test/scala/com/gu/acquisitionsValueCalculatorClient/model/AnnualisedValueResultTest.scala
@@ -1,0 +1,29 @@
+package com.gu.acquisitionsValueCalculatorClient.model
+
+import io.circe.Json
+import org.scalatest.{EitherValues, FlatSpec, Matchers}
+
+class AnnualisedValueResultTest extends FlatSpec with Matchers with EitherValues {
+
+  behavior of "an annualised value calculation"
+
+  val successJson: Json = Json.obj(
+    "AnnualisedValueTwo" -> Json.obj(
+      "amount" -> Json.fromDoubleOrNull(10.0)
+    )
+  )
+
+  val failureJson: Json = Json.obj(
+    "AVError" -> Json.obj(
+      "error" -> Json.fromString("the calculation failed!")
+    )
+  )
+
+  it should "be able to be decoded from JSON if it was a success" in {
+    successJson.as[AnnualisedValueResult].right.value shouldEqual AnnualisedValueTwo(10.0)
+  }
+
+  it should "be able to be decoded from JSON if it was a failure" in {
+    failureJson.as[AnnualisedValueResult].right.value shouldEqual AVError("the calculation failed!")
+  }
+}

--- a/src/test/scala/com/gu/acquisitionsValueCalculatorClient/model/PrintOptionsModelTest.scala
+++ b/src/test/scala/com/gu/acquisitionsValueCalculatorClient/model/PrintOptionsModelTest.scala
@@ -1,0 +1,28 @@
+package com.gu.acquisitionsValueCalculatorClient.model
+
+import io.circe.Json
+import io.circe.syntax._
+import org.scalatest.{EitherValues, FlatSpec, Matchers}
+
+class PrintOptionsModelTest extends FlatSpec with Matchers with EitherValues {
+
+  behavior of "a print options model"
+
+  val json: Json = Json.obj(
+    "product" -> Json.fromString("CONTRIBUTION"),
+    "deliveryCountryCode" -> Json.fromString("US")
+  )
+
+  val printOptionsModel = PrintOptionsModel(
+    product = "CONTRIBUTION",
+    deliveryCountryCode = "US"
+  )
+
+  it should "be able to be decoded from JSON" in {
+    json.as[PrintOptionsModel].right.value shouldEqual printOptionsModel
+  }
+
+  it should "be able to be encode to JSON" in {
+    printOptionsModel.asJson shouldEqual json
+  }
+}


### PR DESCRIPTION
Back to basics - encoders and decoders written with as little magic as possible.

This is motivated by the issues surrounding [#1371](https://github.com/guardian/ophan-data-lake/pull/1371) in the ophan-data-lake repository. ~~Please review, but I'll only merge once I'm in and have confirmed this fixes the problem.~~ In fact, I'll check this fixes the problem first!

```
> testOnly com.gu.acquisitionsValueCalculatorClient.model.*
[info] Compiling 1 Scala source to /Users/guy_dawson/guardian/acquisitions-value-calculator-client/target/scala-2.11/test-classes...
[info] PrintOptionsModelTest:
[info] a print options model
[info] - should be able to be decoded from JSON
[info] - should be able to be encode to JSON
[info] AnnualisedValueResultTest:
[info] an annualised value calculation
[info] - should be able to be decoded from JSON if it was a success
[info] - should be able to be decoded from JSON if it was a failure
[info] AcquisitionModelTest:
[info] an acquisition model
[info] - should be able to be decoded from JSON
[info] - should be able to be encoded to JSON
[info] - should be able to be decoded from JSON when the optional fields are missing
[info] - should be able to be encoded to JSON when the optional fields are missing
[info] Run completed in 239 milliseconds.
[info] Total number of tests run: 8
[info] Suites: completed 3, aborted 0
[info] Tests: succeeded 8, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 2 s, completed 12-Jan-2018 12:28:44
```