### PR TITLE
Make the call to the lambda async & improve error handling

### DIFF
--- a/src/main/scala/com/gu/acquisitionsValueCalculatorClient/service/AnnualisedValueService.scala
+++ b/src/main/scala/com/gu/acquisitionsValueCalculatorClient/service/AnnualisedValueService.scala
@@ -1,11 +1,16 @@
 package com.gu.acquisitionsValueCalculatorClient.service
 
-import com.amazonaws.services.lambda.model.InvokeRequest
+import com.amazonaws.services.lambda.model.{AWSLambdaException, EC2AccessDeniedException, InvocationType, InvokeRequest}
 import com.gu.acquisitionsValueCalculatorClient.model.{AVError, AcquisitionModel, AnnualisedValueResult, AnnualisedValueTwo}
 import io.circe.syntax._
 import io.circe.parser._
 import cats.syntax.either._
+import com.amazonaws.SdkClientException
+import com.amazonaws.services.lambda.AWSLambda
 import com.gu.acquisitionsValueCalculatorClient.utils.ProfileAwareCredentialsProviderChain
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
 
 object AnnualisedValueService extends AnnualisedValueService
 
@@ -15,17 +20,34 @@ class AnnualisedValueService {
     decode[AnnualisedValueResult](json).leftMap(e => "Error: Unable to parse ( " + json + "). " + e.getMessage)
   }
 
-  def getAV(acquisitionModel: AcquisitionModel, accountName: String): Either[String, Double] = {
+  def getAV(acquisitionModel: AcquisitionModel, accountName: String)(implicit executionContext: ExecutionContext): Either[String, Double] = {
 
-    implicit val lambda = AnnualisedValueClient.createLambdaClient(new ProfileAwareCredentialsProviderChain(accountName))
+    implicit val lambda: AWSLambda = AnnualisedValueClient.createLambdaClient(ProfileAwareCredentialsProviderChain(accountName))
 
     val invokeRequest = new InvokeRequest
     invokeRequest.setFunctionName("acquisitions-value-calculator-PROD")
     invokeRequest.setPayload(acquisitionModel.asJson.noSpaces)
-    val response = new String(lambda.invoke(invokeRequest).getPayload.array())
-    annualisedValueResultFromJson(response).flatMap{
-      case AVError(e) => Left(e)
-      case AnnualisedValueTwo(amount) => Right(amount)
+
+    Try(new String(lambda.invoke(invokeRequest).getPayload.array())).fold(
+      error => handleError(error),
+      response => annualisedValueResultFromJson(response).flatMap {
+        case AVError(e) => Left(e)
+        case AnnualisedValueTwo(amount) => Right(amount)
+      }
+    )
+  }
+
+  def handleError(error: Throwable) = Left(
+    error match {
+      case e: AWSLambdaException if e.getErrorCode == "ExpiredTokenException" =>
+        s"Expired credentials - do you have fresh Ophan credentials from Janus? ${error.getMessage}"
+      case e: SdkClientException if e.getMessage == "Unable to load AWS credentials from any provider in the chain" =>
+        s"Missing credentials - do you have fresh Ophan credentials from Janus? ${error.getMessage}"
+      case _ => s"Error during lambda invocation: ${error.getMessage}"
     }
+  )
+
+  def getAsyncAV(acquisitionModel: AcquisitionModel, accountName: String)(implicit executionContext: ExecutionContext): Future[Either[String, Double]] = Future {
+    getAV(acquisitionModel, accountName)
   }
 }

--- a/src/test/scala/com/gu/acquisitionsValueCalculatorClient/services/AnnualisedValueTest.scala
+++ b/src/test/scala/com/gu/acquisitionsValueCalculatorClient/services/AnnualisedValueTest.scala
@@ -5,13 +5,12 @@ import com.gu.acquisitionsValueCalculatorClient.service.AnnualisedValueService
 import org.scalatest._
 import org.scalatest.concurrent.Eventually
 
-class AnnualisedValueTest extends FlatSpec with Matchers with OptionValues with Eventually {
+class AnnualisedValueTest extends AsyncFlatSpec with Matchers with OptionValues with Eventually {
 
   behavior of "av service"
 
   val acquisition = AcquisitionModel(50, "PRINT_SUBSCRIPTION", "GBP", "ONE_OFF", Some("STRIPE"), Some(PrintOptionsModel("VOUCHER_WEEKEND_PLUS", "GB")))
   ignore should "succesfully return AcquisitionModel given valid input -  no payment provider" in {
-    AnnualisedValueService.getAV(acquisition, "ophan") should be ('right)
-
+    AnnualisedValueService.getAsyncAV(acquisition, "ophan").map(_ should be ('right))
   }
 }

--- a/src/test/scala/com/gu/acquisitionsValueCalculatorClient/services/LambdaRunner.scala
+++ b/src/test/scala/com/gu/acquisitionsValueCalculatorClient/services/LambdaRunner.scala
@@ -5,8 +5,15 @@ import com.gu.acquisitionsValueCalculatorClient.service.AnnualisedValueService
 import org.scalatest.concurrent.Eventually
 import org.scalatest.{Matchers, OptionValues}
 
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+
 //For testing locally that the lambda is being called correctly. Run with "sbt test:run"
 object LambdaRunner extends App with Matchers with OptionValues with Eventually {
   val acquisition = AcquisitionModel(50, "CONTRIBUTION", "GBP", "ONE_OFF", Some("STRIPE"), Some(PrintOptionsModel("VOUCHER_WEEKEND_PLUS", "GB")))
-  AnnualisedValueService.getAV(acquisition, "ophan") shouldBe ('right)
+
+  Await.result(
+    AnnualisedValueService.getAsyncAV(acquisition, "ophan").map{_ shouldBe 'right}
+  , 20.seconds)
 }


### PR DESCRIPTION
* Add a new method `getAsyncAV` which returns a `Future` of the AV result - I've left the original synchronous method in place as it's possible that this is more appropriate for some client applications.
* Catch errors thrown by AWS and fold them into the return `Either` with specific handling of errors which are to do with missing credentials as when this used from subs frontend most people will not know that they now require Ophan credentials if they want to test this functionality.